### PR TITLE
Pablo/navbar fix

### DIFF
--- a/src/components/navbar/Navbar.js
+++ b/src/components/navbar/Navbar.js
@@ -4,38 +4,28 @@ import { Link } from "react-router-dom";
 
 export default class Navbar extends React.Component {
 
-  componentDidMount() {
-    const navToggle = Array.prototype.slice.call(document.querySelectorAll('.navbar-burger'), 0);
-    const navLink = Array.prototype.slice.call(document.querySelectorAll('#navMenu .navbar-item'), 0)
-    if (navToggle.length > 0) {
-      navToggle.forEach(function (el) {
-        el.addEventListener('click', function () {
-          let target = el.dataset.target;
-          target = document.getElementById(target);
-          el.classList.toggle('is-active');
-          target.classList.toggle('is-active');
-        });
-      });
-    }
-    if (navLink.length > 0) {
-      navLink.forEach((el) => {
-        el.addEventListener('click', () => {
-          const target = document.getElementById('navMenu');
-          const burgerToggle = document.getElementById('#burger');
-          // burgerToggle.classList.toggle('is-active');
-          target.classList.toggle('is-active');
-        })
-      });
-    }
+  navMenuToggle() {
+    const hotElements = [
+      document.getElementById('homeItem'),
+      document.getElementById('navMenu'),
+      document.getElementById('burger')];
+
+    hotElements.forEach((el) => {
+      el.classList.contains('is-active')
+      ? el.classList.remove('is-active')
+      : el.classList.add('is-active');
+    })
   }
 
   render() {
     return (
       <nav className="navbar" role="navigation" aria-label="main navigation">
         <div className="navbar-brand">
-          <Link className="navbar-item" to="/">Logo and Home</Link>
+          <Link id="homeItem" className="navbar-item" to="/">Logo and Home</Link>
 
-          <span role="button" id="burger" className="navbar-burger" data-target="navMenu" aria-label="menu" aria-expanded="false">
+          <span role="button" id="burger" className="navbar-burger" data-target="navMenu"
+            onClick={this.navMenuToggle}
+            aria-label="menu" aria-expanded="false">
             <span aria-hidden="true"></span>
             <span aria-hidden="true"></span>
             <span aria-hidden="true"></span>
@@ -43,7 +33,7 @@ export default class Navbar extends React.Component {
         </div>
 
         <div id="navMenu" className="navbar-menu navbar-end">
-          <div className="navbar-end">
+          <div className="navbar-end" onClick={this.navMenuToggle}>
             <Link className="navbar-item" to="/me">Me</Link>
             <Link className="navbar-item" to="/discover-categories">Topics</Link>
             <Link className="navbar-item" to="/login">Login</Link>


### PR DESCRIPTION
Fix: Navbar functionality as per comments on #15 by @CKGHarju and @arol

This fix takes out the "componentDidMount" and listeners also. Now onClick listens on a group of elements to perform a toggle on the navbar and subsequent menu. Pressing any link in menu should also close (remove is-active class) thus cleaning up functionality even more.

Not in any TEST, could someone propose a testing-method for the "state" of the component??

Cheers!